### PR TITLE
商品詳細表示機能実装

### DIFF
--- a/app/assets/stylesheets/ordered_items.scss
+++ b/app/assets/stylesheets/ordered_items.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the ordered_items controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :move_to_new, except: [:index]
+  before_action :move_to_new, except: [:index, :show]
 
   def index
     @items = Item.includes(:user).order("created_at DESC")

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,10 +18,14 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params
-    params.require(:item).permit(:image, :name, :explanation, :category_id, :status_id, :shipping_charges_id, :prefecture_id, :days_until_shipping_id, :price).merge(user_id: current_user.id)
+    params.require(:item).permit(:image, :name, :explanation, :category_id, :status_id, :shipping_charge_id, :prefecture_id, :days_until_shipping_id, :price).merge(user_id: current_user.id)
   end
 
   def move_to_new

--- a/app/controllers/ordered_items_controller.rb
+++ b/app/controllers/ordered_items_controller.rb
@@ -1,0 +1,13 @@
+class OrderedItemsController < ApplicationController
+  before_action :move_to_new
+
+  def index
+    @item = Item.find(params[:item_id])
+  end
+
+  private
+
+  def move_to_new
+    redirect_to controller: 'users/sessions', action: :new unless user_signed_in?
+  end
+end

--- a/app/helpers/ordered_items_helper.rb
+++ b/app/helpers/ordered_items_helper.rb
@@ -1,0 +1,2 @@
+module OrderedItemsHelper
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,7 +16,7 @@ class Item < ApplicationRecord
               numericality: { with: /\A[0-9]+\z/, message: 'is not half-width numbers' },
               numericality: { :greater_than_or_equal_to => 300, :less_than_or_equal_to => 9999999,
                               message: 'is out of the setting range' }
-    validates :category_id, :status_id, :shipping_charges_id,
+    validates :category_id, :status_id, :shipping_charge_id,
               :prefecture_id, :days_until_shipping_id,
               numericality: { greater_than_or_equal_to: 1, allow_blank: true}
   end

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -67,7 +67,7 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_charges_id, ShippingCharge.all, :id, :name, {prompt: "--"}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_charge_id, ShippingCharge.all, :id, :name, {prompt: "--"}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,7 +9,7 @@
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outの表示 %>
-      <% if item.ordered_item != nil %>
+      <% if @item.ordered_item != nil %>
         <div class='sold-out'>
           <span>Sold Out!!</span>
         </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -36,7 +36,7 @@
     <% else %>
       <%# 商品が売れていない場合に表示 %>
       <% if OrderedItem.where(item_id: @item.id).empty? %>
-      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <%= link_to '購入画面に進む', item_ordered_items_path(@item.id), class:"item-red-btn"%>
       <% end %>
     <% end %>
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,37 +4,41 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+      <%# 商品が売れている場合は、sold outの表示 %>
+      <% if OrderedItem.where(item_id: @item.id).exists? %>
+        <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
+      <%# 配送料の負担者によって表示を変更 %>
       <span class="item-postage">
-        (税込) 送料込み
+        <% if @item.shipping_charge.id == 2 %>
+          (税込) 送料込み
+        <% else %>
+          (税込) 送料含まず
+        <% end %>
       </span>
     </div>
-
-    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-    <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
-
+    <%# ログインユーザーかつ出品者とログインユーザが同一人物である場合に表示 %>
+    <% if user_signed_in? && @item.user.id == current_user.id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% else %>
+      <%# 商品が売れていない場合に表示 %>
+      <% if OrderedItem.where(item_id: @item.id).empty? %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <% end %>
+    <% end %>
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
     </div>
@@ -42,27 +46,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.days_until_shipping.name %></td>
         </tr>
       </tbody>
     </table>
@@ -77,7 +81,6 @@
       </div>
     </div>
   </div>
-  <%# /商品の概要 %>
 
   <div class="comment-box">
     <form>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,7 +9,7 @@
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outの表示 %>
-      <% if OrderedItem.where(item_id: @item.id).exists? %>
+      <% if item.ordered_item != nil %>
         <div class='sold-out'>
           <span>Sold Out!!</span>
         </div>

--- a/app/views/ordered_items/index.html.erb
+++ b/app/views/ordered_items/index.html.erb
@@ -13,7 +13,7 @@
           <%= "商品説明" %>
         </h2>
         <div class='buy-item-price'>
-          <p class='item-price-text'>¥<%= 999,999,999 %></p>
+          <p class='item-price-text'>¥<%= 999999999 %></p>
           <p class='item-price-sub-text'>（税込）送料込み</p>
         </div>
       </div>

--- a/app/views/shared/_item_lists.html.erb
+++ b/app/views/shared/_item_lists.html.erb
@@ -1,5 +1,5 @@
 <li class='list'>
-  <%= link_to "#" do %>
+  <%= link_to item_path(item.id) do %>
   <div class='item-img-content'>
     <%= image_tag item.image, class: "item-img" %>
     <%# 商品が売れていればsold outの表示 %>

--- a/app/views/shared/_item_lists.html.erb
+++ b/app/views/shared/_item_lists.html.erb
@@ -3,10 +3,10 @@
   <div class='item-img-content'>
     <%= image_tag item.image, class: "item-img" %>
     <%# 商品が売れていればsold outの表示 %>
-    <% if OrderedItem.where(item_id: item.id).exists? %>
-    <div class='sold-out'>
-      <span>Sold Out!!</span>
-    </div>
+    <% if item.ordered_item != nil %>
+      <div class='sold-out'>
+        <span>Sold Out!!</span>
+      </div>
     <% end %>
   </div>
   <div class='item-info'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: { registrations: 'users/registrations', sessions: 'users/sessions' }
   root "items#index"
-  resources :items, only: [:new, :create, :destroy]
+  resources :items, only: [:new, :create, :show, :destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: { registrations: 'users/registrations', sessions: 'users/sessions' }
   root "items#index"
-  resources :items, only: [:new, :create, :show, :destroy]
+  resources :items, only: [:new, :create, :show, :destroy] do
+    resources :ordered_items, only: :index
+  end
 end

--- a/spec/helpers/ordered_items_helper_spec.rb
+++ b/spec/helpers/ordered_items_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the OrderedItemsHelper. For example:
+#
+# describe OrderedItemsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe OrderedItemsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/ordered_items_request_spec.rb
+++ b/spec/requests/ordered_items_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "OrderedItems", type: :request do
+
+end


### PR DESCRIPTION
#What
商品詳細を表示し、ユーザーごと（出品者・非出品者ごと）に表示させる画面を変える

#Why
商品の詳細を閲覧可能とすること及びユーザーによって可能なアクションを変えるため

#スクショ
商品情報の表示：https://gyazo.com/d544467c32ec9eb49dce4d9eb362d267
未ログイン状態：https://gyazo.com/3b38085243d69e629487861ef934ce5f
ログイン状態（出品者）：https://gyazo.com/7bcc6620db1e2be7a044e889c81e0779
ログイン状態（非出品者）：https://gyazo.com/9142482a10dda37fa69862ed68a79172